### PR TITLE
Update sort order to use plan date rather than creation date

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ instance.prototype.processServicesData = function (result) {
 
 	for (let i = 0; i < result.length; i++) {
 		let serviceTypeId = result[i].id;
-		let plans_url = `${baseAPIUrl}/service_types/${serviceTypeId}/plans?filter=future&per_page=${perpage}`;
+		let plans_url = `${baseAPIUrl}/service_types/${serviceTypeId}/plans?filter=future&per_page=${perpage}&order=sort_date`;
 		
 		let serviceListObj = {};
 		serviceListObj.id = result[i].id;
@@ -813,7 +813,7 @@ instance.prototype.processLiveData = function (result) {
 instance.prototype.getPlanIdOfServiceType = function (serviceTypeId) {
 	var self = this;
 	
-	let plans_url = `${baseAPIUrl}/service_types/${serviceTypeId}/plans?filter=future&per_page=1`;
+	let plans_url = `${baseAPIUrl}/service_types/${serviceTypeId}/plans?filter=future&per_page=1&order=sort_date`;
 	
 	return new Promise(function (resolve, reject) {	
 		self.doRest('GET', plans_url, {})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "planningcenter-serviceslive",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"api_version": "1.0.0",
 	"keywords": [ "Show Control" ],
 	"manufacturer": "Planning Center Online",


### PR DESCRIPTION
Fixes #7 

The default sort order was returning plans ordered by creation date. This is a problem if, for example, you created a plan for Christmas services back in June. Now that plan is stuck at the top of the list, rather than down with the December plans.

This PR updates the API call to ask for the plans sorted by the `sort date` rather than the date the plan was created. Here is Planning Center's definition of the `sort date`:
> A time representing the chronological first Service Time, used to sort plan chronologically. If no Service Times exist, it uses Rehearsal Times, then Other Times, then NOW.