### PR TITLE
Fix variable naming in setPlanIdForPolling_specific action

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -471,8 +471,8 @@ module.exports = {
 				},
 			],
 			callback: async function (event) {
-				let planid = await self.parseVariablesInString(event.options.planid)
-				let serviceTypeId = self.getServiceIdFromPlanId(planid)
+				let planId = await self.parseVariablesInString(event.options.planid)
+				let serviceTypeId = self.getServiceIdFromPlanId(planId)
 
 				self.lastServiceTypeId = serviceTypeId
 				self.lastPlanId = planId


### PR DESCRIPTION
Change 'planid' to 'planId' on lines 474-475 to match the camelCase variable used on line 478 (self.lastPlanId = planId). This fixes the undefined variable error when using the 'Set Plan Id for Polling (Specific Plan Id)' action.

Resolves #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)